### PR TITLE
Add cargo-husky and typos pre-commit hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "ams"
 version = "0.1.0"
 dependencies = [
+ "cargo-husky",
  "chrono",
  "clap",
  "thiserror",
@@ -81,6 +82,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,9 @@ edition = "2021"
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 thiserror = "1"
+
+[dev-dependencies]
+cargo-husky = { version = "1", features = ["precommit-hook", "run-cargo-check", "run-cargo-clippy", "run-cargo-fmt"] }
+
+[package.metadata.husky.hooks]
+pre-commit = "typos && cargo fmt -- --check && cargo clippy -- -D warnings"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,44 @@ args = []
 refresh_rate_ms = 1000
 ```
 
+## Contributing
+
+### Prerequisites
+
+This project uses [cargo-husky](https://github.com/rhysd/cargo-husky) for git hooks and [typos](https://github.com/crate-ci/typos) for spell checking.
+
+Install typos before contributing:
+
+```bash
+cargo install typos-cli
+```
+
+### Pre-commit Hooks
+
+After cloning and running `cargo build`, cargo-husky will automatically set up a pre-commit hook that runs:
+
+1. `typos` - Spell checker for source code
+2. `cargo fmt -- --check` - Code formatting check
+3. `cargo clippy -- -D warnings` - Linting
+
+If any of these fail, the commit will be rejected. Fix the issues and try again.
+
+### Running Checks Manually
+
+```bash
+# Run typos spell checker
+typos
+
+# Fix typos automatically (use with caution)
+typos -w
+
+# Check formatting
+cargo fmt -- --check
+
+# Run clippy
+cargo clippy -- -D warnings
+```
+
 ## License
 
 MIT

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,19 @@
+# typos configuration
+# https://github.com/crate-ci/typos
+
+[default]
+extend-ignore-re = [
+    # UUIDs
+    "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+]
+
+[files]
+extend-exclude = [
+    "Cargo.lock",
+    "target/",
+    ".git/",
+]
+
+[default.extend-words]
+# Add project-specific words that should not be flagged as typos
+ams = "ams"


### PR DESCRIPTION
## Summary

- Add cargo-husky as a dev dependency for git hooks management
- Configure pre-commit hook to run typos spell checker, cargo fmt, and clippy
- Create typos.toml configuration file for project-specific spell checking rules
- Document the contributing workflow and prerequisites in README

Closes #13

## Test plan

- [ ] Clone the repo fresh and run `cargo build` to verify cargo-husky installs the pre-commit hook
- [ ] Make a commit with a typo and verify the hook catches it
- [ ] Make a commit with formatting issues and verify the hook catches it
- [ ] Make a commit with clippy warnings and verify the hook catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)