### PR TITLE
Split CONTRIBUTING and LICENSE sections from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Prerequisites
+
+This project uses [cargo-husky](https://github.com/rhysd/cargo-husky) for git hooks and [typos](https://github.com/crate-ci/typos) for spell checking.
+
+Install typos before contributing:
+
+```bash
+cargo install typos-cli
+```
+
+## Pre-commit Hooks
+
+After cloning and running `cargo build`, cargo-husky will automatically set up a pre-commit hook that runs:
+
+1. `typos` - Spell checker for source code
+2. `cargo fmt -- --check` - Code formatting check
+3. `cargo clippy -- -D warnings` - Linting
+
+If any of these fail, the commit will be rejected. Fix the issues and try again.
+
+## Running Checks Manually
+
+```bash
+# Run typos spell checker
+typos
+
+# Fix typos automatically (use with caution)
+typos -w
+
+# Check formatting
+cargo fmt -- --check
+
+# Run clippy
+cargo clippy -- -D warnings
+```
+
+## Test Coverage
+
+This project enforces 100% test coverage. All new code must include tests.
+
+Install cargo-llvm-cov for coverage reports:
+
+```bash
+cargo install cargo-llvm-cov
+```
+
+Run coverage locally:
+
+```bash
+# Run tests with coverage check (fails if below 100%)
+cargo llvm-cov --fail-under-lines 100
+
+# Generate HTML report
+cargo llvm-cov --html --open
+
+# Generate lcov report
+cargo llvm-cov --lcov --output-path lcov.info
+```
+
+Coverage reports are automatically generated in CI and uploaded as artifacts.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tupe12334
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -119,67 +119,8 @@ refresh_rate_ms = 1000
 
 ## Contributing
 
-### Prerequisites
-
-This project uses [cargo-husky](https://github.com/rhysd/cargo-husky) for git hooks and [typos](https://github.com/crate-ci/typos) for spell checking.
-
-Install typos before contributing:
-
-```bash
-cargo install typos-cli
-```
-
-### Pre-commit Hooks
-
-After cloning and running `cargo build`, cargo-husky will automatically set up a pre-commit hook that runs:
-
-1. `typos` - Spell checker for source code
-2. `cargo fmt -- --check` - Code formatting check
-3. `cargo clippy -- -D warnings` - Linting
-
-If any of these fail, the commit will be rejected. Fix the issues and try again.
-
-### Running Checks Manually
-
-```bash
-# Run typos spell checker
-typos
-
-# Fix typos automatically (use with caution)
-typos -w
-
-# Check formatting
-cargo fmt -- --check
-
-# Run clippy
-cargo clippy -- -D warnings
-```
-
-### Test Coverage
-
-This project enforces 100% test coverage. All new code must include tests.
-
-Install cargo-llvm-cov for coverage reports:
-
-```bash
-cargo install cargo-llvm-cov
-```
-
-Run coverage locally:
-
-```bash
-# Run tests with coverage check (fails if below 100%)
-cargo llvm-cov --fail-under-lines 100
-
-# Generate HTML report
-cargo llvm-cov --html --open
-
-# Generate lcov report
-cargo llvm-cov --lcov --output-path lcov.info
-```
-
-Coverage reports are automatically generated in CI and uploaded as artifacts.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, pre-commit hooks, and contribution guidelines.
 
 ## License
 
-MIT
+MIT - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Create CONTRIBUTING.md with development setup, pre-commit hooks, and contribution guidelines
- Create LICENSE file with full MIT license text
- Update README.md to link to these new files instead of containing full content

Closes #23

## Test plan
- [x] All existing tests pass
- [x] Pre-commit hooks pass (typos, fmt, clippy)
- [ ] Verify links in README.md work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)